### PR TITLE
create new addOption function in AbstractQuery

### DIFF
--- a/src/DBAL/Query/AbstractQuery.php
+++ b/src/DBAL/Query/AbstractQuery.php
@@ -97,11 +97,15 @@ abstract class AbstractQuery implements QueryInterface
 
         return $this;
     }
-    
+
     /**
+     * Add an option on the query.
+     *
+     * @param string $name
+     * @param mixed $value
      * @return $this
      */
-    public function addOption(string $name, array $value)
+    public function addOption(string $name, mixed $value)
     {
         $this->options[$name] = $value;
 

--- a/src/DBAL/Query/AbstractQuery.php
+++ b/src/DBAL/Query/AbstractQuery.php
@@ -101,8 +101,8 @@ abstract class AbstractQuery implements QueryInterface
     /**
      * Add an option on the query.
      *
-     * @param string $name
      * @param mixed $value
+     * 
      * @return $this
      */
     public function addOption(string $name, $value)

--- a/src/DBAL/Query/AbstractQuery.php
+++ b/src/DBAL/Query/AbstractQuery.php
@@ -97,6 +97,16 @@ abstract class AbstractQuery implements QueryInterface
 
         return $this;
     }
+    
+    /**
+     * @return $this
+     */
+    public function addOption(string $name, array $value)
+    {
+        $this->options[$name] = $value;
+
+        return $this;
+    }
 
     /**
      * Execute the query.

--- a/src/DBAL/Query/AbstractQuery.php
+++ b/src/DBAL/Query/AbstractQuery.php
@@ -105,7 +105,7 @@ abstract class AbstractQuery implements QueryInterface
      * @param mixed $value
      * @return $this
      */
-    public function addOption(string $name, mixed $value)
+    public function addOption(string $name, $value)
     {
         $this->options[$name] = $value;
 


### PR DESCRIPTION
I created an addOption function because, setOptions overrides all previous options. For example a select ['id,' name'].