### PR TITLE
Fixed error on count method

### DIFF
--- a/src/DBAL/Query/OrmQuery.php
+++ b/src/DBAL/Query/OrmQuery.php
@@ -57,7 +57,7 @@ class OrmQuery extends AbstractQuery implements QueryInterface
         }
 
         $query = new self($this->recordManager, $this->name, self::SEARCH_COUNT);
-        $query->setParameters($this->recordManager->getExpressionBuilder()->normalizeDomains($this->parameters));
+        $query->setParameters($this->parameters);
 
         return (int) $query->execute();
     }


### PR DESCRIPTION
Fix Odoo error on count method of getQuery
Issue : #26 

The problem was fixed by removing the use of the normalizeDomains function from the count method.